### PR TITLE
Binder environment correct (#304)

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - esmpy
 - intake-xarray
 - geopy
-- xesmf
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - cartopy
 - intake-xarray
 - geopy
-- xesmf
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -8,10 +8,10 @@ dependencies:
 - bottleneck
 - netCDF4
 - xarray
-- cartopy<0.20
+- cartopy
 - esmpy
 - geopy
-- xesmf
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython


### PR DESCRIPTION
* make sure binder built with newest xesmf version

* same as before

Co-authored-by: Miguel Jimenez <mjimen17@jhu.edu>